### PR TITLE
修正1.0 api文档中orderBy用函数作为参数的例子

### DIFF
--- a/src/api/index.md
+++ b/src/api/index.md
@@ -2207,7 +2207,7 @@ type: api
   <div id="orderby-compare-example" class="demo">
     <button @click="order = order * -1">Reverse Sort Order</button>
     <ul>
-      <li v-for="user in users | orderBy ageByTen">
+      <li v-for="user in users | orderBy ageByTen order">
         {{ user.name }} - {{ user.age }}
       </li>
     </ul>


### PR DESCRIPTION
orderBy用函数作为参数排序的举例，少写了个顺序参数