### PR TITLE
对show描述有误

### DIFF
--- a/src/guide/transitions.md
+++ b/src/guide/transitions.md
@@ -160,7 +160,7 @@ If the `transition` attribute has no value, the classes will default to `.v-tran
 
 ### Transition Flow Details
 
-When the `show` property changes, Vue.js will insert or remove the `<div>` element accordingly, and apply transition classes as specified below:
+When the `show` property changes, Vue.js will show or hide the `<div>` element accordingly, and apply transition classes as specified below:
 
 - When `show` becomes false, Vue.js will:
   1. Call `beforeLeave` hook;


### PR DESCRIPTION
在条件渲染一章中，有如下原文：
“不同的是有 v-show 的元素会始终渲染并保持在 DOM 中。v-show 是简单的切换元素的 CSS 属性 display。”
而过渡流程详解中，有如下原文：
“当 show 属性改变时，Vue.js 将相应地插入或删除 <div> 元素，按照如下规则改变过渡的 CSS 类名：”
这里应该是   相应的显示或隐藏，而非插入或删除，因为 v-show 的元素会始终渲染并保持在 DOM 中。
此处产生了冲突