### PR TITLE
fix some envent wrong at guide/forms.md lazy

### DIFF
--- a/src/guide/forms.md
+++ b/src/guide/forms.md
@@ -294,7 +294,7 @@ vm.selected.number // -> 123
 
 ### lazy
 
-By default, `v-model` syncs the input with the data after each `input` event. You can add a `lazy` attribute to change the behavior to sync after `change` events:
+By default, `v-model` syncs the input with the data after each `change` event. You can add a `lazy` attribute to change the behavior to sync after `blur` events:
 
 ``` html
 <!-- synced after "change" instead of "input" -->


### PR DESCRIPTION
通过学习本教程，发现laze属性是在input失去焦点时触发数据更新，因此认为默认是change事件触发更新，添加laze后是blur事件触发更新。
