### PR TITLE
修复“货币输入”例子代码错误

### DIFF
--- a/src/v2/guide/components.md
+++ b/src/v2/guide/components.md
@@ -622,7 +622,12 @@ Vue.component('currency-input', {
     }
   }
 })
-new Vue({ el: '#currency-input-example' })
+new Vue({
+  el: '#currency-input-example',
+  data: {
+    price: 0
+  }
+})
 </script>
 {% endraw %}
 


### PR DESCRIPTION
[Vue warn]: Property or method "price" is not defined on the instance but referenced during render. Make sure to declare reactive data properties in the data option. 
(found in root instance)
warn @ vue.js:515