### PR TITLE
Update events.md——修改自定义按键修饰符例子

### DIFF
--- a/src/v2/guide/events.md
+++ b/src/v2/guide/events.md
@@ -231,7 +231,7 @@ methods: {
 
 ``` js
 // 可以使用 v-on:keyup.f1
-Vue.config.keyCodes.f1 = 112
+Vue.config.keyCodes.f2 = 113
 ```
 
 ## 按键修饰符


### PR DESCRIPTION
自定义按键修饰符别名的例子中，设定了F1的别名，但是与各大浏览器的默认help快捷键冲突（除了Firefox），因此写demo时会出现跳转页面，覆盖了键值本来要绑定的事件。
建议修改为没有默认快捷键的例子，比如f2，该段改为：
``` js
// 可以使用 v-on:keyup.f1
Vue.config.keyCodes.f2 = 113
```