### PR TITLE
更改翻译不当

### DIFF
--- a/src/v2/guide/instance.md
+++ b/src/v2/guide/instance.md
@@ -73,7 +73,7 @@ vm.$watch('a', function (newVal, oldVal) {
 })
 ```
 
-<p class="tip">注意，不要在实例属性或者回调函数中（如 `vm.$watch('a', newVal => this.myMethod())`）使用[箭头函数](https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Functions/Arrow_functions)。因为箭头函数绑定父级上下文，所以 `this` 不会像预想的一样是 Vue 实例，而是 `this.myMethod` 未被定义。</p>
+<p class="tip">注意，不要在实例属性或者回调函数中（如 `vm.$watch('a', newVal => this.myMethod())`）使用[箭头函数](https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Functions/Arrow_functions)。因为箭头函数绑定父级上下文，所以 `this` 不会像预想的一样是 Vue 实例，而且 `this.myMethod` 是未被定义的。</p>
 
 实例属性和方法的完整列表中查阅 [API 参考](../api/#实例属性)。
 


### PR DESCRIPTION
“因为箭头函数绑定父级上下文，所以 `this` 不会像预想的一样是 Vue 实例” ，这句话后跟 “而是” 会让人误解。