### PR TITLE
Update plugins.md

### DIFF
--- a/src/v2/guide/plugins.md
+++ b/src/v2/guide/plugins.md
@@ -68,7 +68,7 @@ Vue.use(MyPlugin, { someOption: true })
 
 `Vue.use` 会自动阻止注册相同插件多次，届时只会注册一次该插件。
 
-一些插件，如 `vue-router` 如果 `Vue` 是全局变量则自动调用 `Vue.use()` 。不过在模块环境中应当始终显式调用 `Vue.use()` :
+Vue.js 官方提供的一些插件（例如 `vue-router`），如果检测到 `Vue` 是可访问的全局变量，这些插件会自动调用 `Vue.use()`。然而在例如 CommonJS 的模块环境中，你应该始终显式地调用 `Vue.use()`：
 
 ``` js
 // 通过 Browserify 或 Webpack 使用 CommonJS 兼容模块
@@ -81,11 +81,23 @@ Vue.use(VueRouter)
 
 [awesome-vue](https://github.com/vuejs/awesome-vue#components--libraries) 集合了来自社区贡献的数以千计的插件和库。
 
+***
 
+### 译注：
 
+> 如果检测到 `Vue` 是可访问的全局变量，这些插件会自动调用 `Vue.use()`
+
+可以参考 https://github.com/vuejs/vue-router/blob/dev/src/index.js#L233
+``` javascript
+if (inBrowser && window.Vue) {
+  window.Vue.use(VueRouter)
+}
+```
 
 ***
 
-> 原文： http://vuejs.org/guide/plugins.html
+***
+
+> 原文： http://vuejs.org/v2/guide/plugins.html
 
 ***

--- a/src/v2/guide/plugins.md
+++ b/src/v2/guide/plugins.md
@@ -71,7 +71,7 @@ Vue.use(MyPlugin, { someOption: true })
 Vue.js 官方提供的一些插件（例如 `vue-router`），如果检测到 `Vue` 是可访问的全局变量，这些插件会自动调用 `Vue.use()`。然而在例如 CommonJS 的模块环境中，你应该始终显式地调用 `Vue.use()`：
 
 ``` js
-// 通过 Browserify 或 Webpack 使用 CommonJS 兼容模块
+// 在使用由 Browserify 或 webpack 这些模块打包工具，提供的 CommonJS 模块环境时
 var Vue = require('vue')
 var VueRouter = require('vue-router')
 

--- a/src/v2/guide/plugins.md
+++ b/src/v2/guide/plugins.md
@@ -68,10 +68,10 @@ Vue.use(MyPlugin, { someOption: true })
 
 `Vue.use` 会自动阻止注册相同插件多次，届时只会注册一次该插件。
 
-Vue.js 官方提供的一些插件（例如 `vue-router`），如果检测到 `Vue` 是可访问的全局变量，这些插件会自动调用 `Vue.use()`。然而在例如 CommonJS 的模块环境中，你应该始终显式地调用 `Vue.use()`：
+Vue.js 官方提供的一些插件 (例如 `vue-router`) 在检测到 `Vue` 是可访问的全局变量时会自动调用 `Vue.use()`。然而在例如 CommonJS 的模块环境中，你应该始终显式地调用 `Vue.use()`：
 
 ``` js
-// 在使用由 Browserify 或 webpack 这些模块打包工具，提供的 CommonJS 模块环境时
+// 用 Browserify 或 webpack 提供的 CommonJS 模块环境时
 var Vue = require('vue')
 var VueRouter = require('vue-router')
 
@@ -80,21 +80,6 @@ Vue.use(VueRouter)
 ```
 
 [awesome-vue](https://github.com/vuejs/awesome-vue#components--libraries) 集合了来自社区贡献的数以千计的插件和库。
-
-***
-
-### 译注：
-
-> 如果检测到 `Vue` 是可访问的全局变量，这些插件会自动调用 `Vue.use()`
-
-可以参考 https://github.com/vuejs/vue-router/blob/dev/src/index.js#L233
-``` javascript
-if (inBrowser && window.Vue) {
-  window.Vue.use(VueRouter)
-}
-```
-
-***
 
 ***
 


### PR DESCRIPTION
Some plugins provided by Vue.js official plugins such as `vue-router` automatically calls `Vue.use()` if `Vue` is available as a global variable. However in a module environment such as CommonJS, you always need to call `Vue.use()` explicitly:
Vue.js 官方提供的一些插件（例如 `vue-router`），如果检测到 `Vue` 是可访问的全局变量，这些插件会自动调用 `Vue.use()`。然而在例如 CommonJS 的模块环境中，你应该始终显式地调用 `Vue.use()`：

可以参考 https://github.com/vuejs/vue-router/blob/dev/src/index.js#L233
``` javascript
if (inBrowser && window.Vue) {
  window.Vue.use(VueRouter)
}