### PR TITLE
优化绑定DOM属性示例中时间显示和文字表述

### DIFF
--- a/src/v2/guide/index.md
+++ b/src/v2/guide/index.md
@@ -54,7 +54,7 @@ var app = new Vue({
 </script>
 {% endraw %}
 
-我们已经生成了我们的第一个 Vue 应用！看起来这跟单单渲染一个字符串模板非常类似，但是 Vue 在背后做了大量工作。现在数据和 DOM 已经被绑定在一起，所有的元素都是**响应式的**。我们如何知道？打开你的浏览器的控制台（就在这个页面打开），并修改 `app.message`，你将看到上例相应地更新。
+我们已经生成了我们的第一个 Vue 应用！看起来这跟单单渲染一个字符串模板非常类似，但是 Vue 在背后做了大量工作。现在数据和 DOM 已经被绑定在一起，所有的元素都是**响应式的**。我们该如何知道呢？打开你的浏览器的控制台（就在这个页面打开），并修改 `app.message`，你将看到上例相应地更新。
 
 除了文本插值，我们还可以采用这样的方式绑定 DOM 元素属性：
 
@@ -69,7 +69,7 @@ var app = new Vue({
 var app2 = new Vue({
   el: '#app-2',
   data: {
-    message: '页面加载于 ' + new Date()
+    message: '页面加载于 ' + new Date().toLocaleString()
   }
 })
 ```
@@ -83,7 +83,7 @@ var app2 = new Vue({
 var app2 = new Vue({
   el: '#app-2',
   data: {
-    message: '页面加载于 ' + new Date()
+    message: '页面加载于 ' + new Date().toLocaleString()
   }
 })
 </script>

--- a/src/v2/guide/index.md
+++ b/src/v2/guide/index.md
@@ -69,7 +69,7 @@ var app = new Vue({
 var app2 = new Vue({
   el: '#app-2',
   data: {
-    message: '页面加载于 ' + new Date().toLocaleString()
+    message: '页面加载于 ' + new Date()
   }
 })
 ```
@@ -83,7 +83,7 @@ var app2 = new Vue({
 var app2 = new Vue({
   el: '#app-2',
   data: {
-    message: '页面加载于 ' + new Date().toLocaleString()
+    message: '页面加载于 ' + new Date()
   }
 })
 </script>

--- a/src/v2/guide/syntax.md
+++ b/src/v2/guide/syntax.md
@@ -25,7 +25,7 @@ Mustache 标签将会被替代为对应数据对象上 `msg` 属性的值。无�
 通过使用 [v-once 指令](../api/#v-once)，你也能执行一次性地插值，当数据改变时，插值处的内容不会更新。但请留心这会影响到该节点上所有的数据绑定：
 
 ``` html
-<span v-once>This will never change: {{ msg }}</span>
+<span v-once>这个将不会改变: {{ msg }}</span>
 ```
 
 ### 纯 HTML
@@ -86,7 +86,7 @@ Mustache 不能在 HTML 属性中使用，应使用 [v-bind 指令](../api/#v-bi
 指令（Directives）是带有 `v-` 前缀的特殊属性。指令属性的值预期是**单一 JavaScript 表达式**（除了 `v-for`，之后再讨论）。指令的职责就是当其表达式的值改变时相应地将某些行为应用到 DOM 上。让我们回顾一下在介绍里的例子：
 
 ``` html
-<p v-if="seen">Now you see me</p>
+<p v-if="seen">现在你看到我了</p>
 ```
 
 这里， `v-if` 指令将根据表达式 `seen` 的值的真假来移除/插入 `<p>` 元素。


### PR DESCRIPTION
优化绑定DOM属性示例中的时间显示，新增代码中使用的是普通方法，不会增加阅读难度，虽然英文原版示例中并没有，但是更改后更加符合国人的阅读习惯，易于理解。
优化文字表述，原英文中“How do we know?”，翻译为”我们该如何知道呢？“语句更加通顺，原来那句“我们如何知道？”，怎么读怎么拗口，像是机器翻译的。
在介绍指令时提出“让我们回顾一下在介绍里的例子”，下面给出的示例中在介绍一章中“Now you see me”，是已经翻译为中文的，但是在这里再次回顾时却没有更改，建议进行翻译。同理在插值-->文本一节中的“This will never change”，也应翻译为“这个将不会改变”。
总结起来感觉，前几章中基本上英文都被翻译为中文，包括代码中的一部分文本内容，但是到了后几张，代码中的文本内容就不再进行翻译，这种前后不一致，不知道是不是有意为之。