### PR TITLE
翻译校对问题

### DIFF
--- a/src/v2/guide/index.md
+++ b/src/v2/guide/index.md
@@ -54,7 +54,7 @@ var app = new Vue({
 </script>
 {% endraw %}
 
-我们已经生成了我们的第一个 Vue 应用！看起来这跟单单渲染一个字符串模板非常类似，但是 Vue 在背后做了大量工作。现在数据和 DOM 已经被绑定在一起，所有的元素都是**响应式的**。我们如何知道？打开你的浏览器的控制台（就在这个页面打开），并修改 `app.message`，你将看到上例相应地更新。
+我们已经生成了我们的第一个 Vue 应用！看起来这跟单单渲染一个字符串模板非常类似，但是 Vue 在背后做了大量工作。现在数据和 DOM 已经被绑定在一起，所有的元素都是**响应式的**。我们该如何知道呢？打开你的浏览器的控制台（就在这个页面打开），并修改 `app.message`，你将看到上例相应地更新。
 
 除了文本插值，我们还可以采用这样的方式绑定 DOM 元素属性：
 
@@ -69,7 +69,7 @@ var app = new Vue({
 var app2 = new Vue({
   el: '#app-2',
   data: {
-    message: '页面加载于 ' + new Date()
+    message: '页面加载于 ' + new Date().toLocaleString()
   }
 })
 ```
@@ -83,7 +83,7 @@ var app2 = new Vue({
 var app2 = new Vue({
   el: '#app-2',
   data: {
-    message: '页面加载于 ' + new Date()
+    message: '页面加载于 ' + new Date().toLocaleString()
   }
 })
 </script>

--- a/src/v2/guide/index.md
+++ b/src/v2/guide/index.md
@@ -69,7 +69,7 @@ var app = new Vue({
 var app2 = new Vue({
   el: '#app-2',
   data: {
-    message: '页面加载于 ' + new Date().toLocaleString()
+    message: '页面加载于 ' + new Date()
   }
 })
 ```
@@ -83,7 +83,7 @@ var app2 = new Vue({
 var app2 = new Vue({
   el: '#app-2',
   data: {
-    message: '页面加载于 ' + new Date().toLocaleString()
+    message: '页面加载于 ' + new Date()
   }
 })
 </script>

--- a/src/v2/guide/installation.md
+++ b/src/v2/guide/installation.md
@@ -90,7 +90,7 @@ $ npm run dev
 
 ### 运行时 + 编译器 vs. 只包含运行时
 
-如果你需要在客户端编译模板 (比如传入一个字符串的 `template` 选项，或挂载到一个元素上并以其内部的 HTML 作为模板)，你将需要加上编译器，即完整版的构建：
+如果你需要在客户端编译模板 (比如传入一个字符串给`template` 选项，或挂载到一个元素上并以其内部的 HTML 作为模板)，你将需要加上编译器，即完整版的构建：
 
 ``` js
 // 需要编译器
@@ -140,7 +140,7 @@ rollup({
 
 #### Browserify
 
-Add to your project's `package.json`:
+添加到你项目的 `package.json`:
 
 ``` js
 {
@@ -157,7 +157,7 @@ Add to your project's `package.json`:
 
 CommonJS 和 ES Module 构建是用于打包工具的，因此我们不提供压缩后的版本。你有必要在打最终包的时候压缩它们。
 
-CommonJS 和 ES Module 构建同时保留里原始的 `process.env.NODE_ENV` 检测，以决定它们应该运行在什么模式下。你应该使用适当的打包工具配置来替换它们的环境变量以便控制 Vue 所运行的模式。把 `process.env.NODE_ENV` 替换为字符串字面量同样可以让 UglifyJS 之类的压缩工具完全丢掉仅供开发环境的代码段，减少最终的文件尺寸。
+CommonJS 和 ES Module 构建同时保留原始的 `process.env.NODE_ENV` 检测，以决定它们应该运行在什么模式下。你应该使用适当的打包工具配置来替换它们的环境变量以便控制 Vue 所运行的模式。把 `process.env.NODE_ENV` 替换为字符串字面量同样可以让 UglifyJS 之类的压缩工具完全丢掉仅供开发环境的代码段，减少最终的文件尺寸。
 
 #### Webpack
 
@@ -204,17 +204,17 @@ rollup({
 NODE_ENV=production browserify -g envify -e main.js | uglifyjs -c -m > build.js
 ```
 
-也可以移步到[生产环境部署提示](deployment.html).
+也可以移步到[生产环境部署提示](deployment.html)。
 
 ### CSP 环境
 
-有些环境，如 Google Chrome Apps ，强制应用内容安全策略 (CSP) ，不能使用 new Function() 对表达式求值。这时可以用 CSP 兼容版本。独立的构建取决于该功能编译模板，所以无法使用这些环境。
+有些环境，如 Google Chrome Apps ，强制应用内容安全策略 (CSP) ，不能使用 `new Function()` 对表达式求值。这时可以用 CSP 兼容版本。独立的构建取决于该功能编译模板，所以无法使用这些环境。
 
 另一方面，运行时构建的是完全兼容 CSP 的。当通过 [Webpack + vue-loader](https://github.com/vuejs-templates/webpack-simple) 或者 [Browserify + vueify](https://github.com/vuejs-templates/browserify-simple) 构建时，在 CSP 环境中模板将被完美预编译到 `render` 函数中。
 
 ## 开发版构建
 
-**重要**: Github 仓库的 `/dist` 文件夹只有在新版本发布时才会更新。如果想要使用 Github 上 Vue 最新的源码，你需要自己构建。
+**重要**: Github 仓库的 `/dist` 文件夹只有在新版本发布时才会更新。如果想要使用 Github 上 Vue 最新的源码，你需要自己构建！
 
 ``` bash
 git clone https://github.com/vuejs/vue.git node_modules/vue

--- a/src/v2/guide/syntax.md
+++ b/src/v2/guide/syntax.md
@@ -25,7 +25,7 @@ Mustache 标签将会被替代为对应数据对象上 `msg` 属性的值。无�
 通过使用 [v-once 指令](../api/#v-once)，你也能执行一次性地插值，当数据改变时，插值处的内容不会更新。但请留心这会影响到该节点上所有的数据绑定：
 
 ``` html
-<span v-once>This will never change: {{ msg }}</span>
+<span v-once>这个将不会改变: {{ msg }}</span>
 ```
 
 ### 纯 HTML
@@ -86,7 +86,7 @@ Mustache 不能在 HTML 属性中使用，应使用 [v-bind 指令](../api/#v-bi
 指令（Directives）是带有 `v-` 前缀的特殊属性。指令属性的值预期是**单一 JavaScript 表达式**（除了 `v-for`，之后再讨论）。指令的职责就是当其表达式的值改变时相应地将某些行为应用到 DOM 上。让我们回顾一下在介绍里的例子：
 
 ``` html
-<p v-if="seen">Now you see me</p>
+<p v-if="seen">现在你看到我了</p>
 ```
 
 这里， `v-if` 指令将根据表达式 `seen` 的值的真假来移除/插入 `<p>` 元素。


### PR DESCRIPTION
”Add to your project's “我翻译为“添加到你项目的 ”
“passing a string to the template option, ”,原译者翻译为“传入一个字符串的 `template`选项”，我认为不妥，我觉得应该翻译为“传入一个字符串给`template`选项”，（ps:虽然我咨询道友之后，道友认为原译者翻译较好，但是我不服气啊）。
“new Function() ”，原文中是有引号的。
“you will have to build it yourself!”，原文中带有强调语气，所以用了感叹号，原译者翻译之后语气平和，但是这个感叹号还是留着吧，以示警示作用。
“Add to your project's ”，原译者没有翻译，我查看全文之后认为应该做出翻译，“添加到你项目的”。
其他就是标点符号或者多字的问题。我做的校对比较细小或者微不足道，自身能力也不足，还请仔细甄别之后修改。