### PR TITLE
fix wrong translation for $parent

### DIFF
--- a/src/v2/api/index.md
+++ b/src/v2/api/index.md
@@ -888,7 +888,7 @@ if (version === 2) {
 
   指定已创建的实例之父实例，在两者之间建立父子关系。子实例可以用 `this.$parent` 访问父实例，子实例被推入父实例的 `$children` 数组中。
 
-  <p class="tip">同时使用 `$parent` 和 `$children` 有冲突 - 他们作为同一个入口 。更推荐用 props 和 events 实现父子组件通信</p>
+  <p class="tip">节制地使用 `$parent` 和 `$children` - 它们的主要目的是作为访问组件的应急方法。更推荐用 props 和 events 实现父子组件通信</p>
 
 ### mixins
 


### PR DESCRIPTION
原先的翻译似乎完全误解了原文档的意思 😅  而且也翻译得很奇怪，用户很难理解。

![image](https://user-images.githubusercontent.com/559179/30270803-8fb78470-9720-11e7-9a7d-d4dfd12309a2.png)


![image](https://user-images.githubusercontent.com/559179/30270893-d242ac70-9720-11e7-811a-f8cb920bc4ba.png)

