### PR TITLE
Update syntax.md

### DIFF
--- a/src/v2/guide/syntax.md
+++ b/src/v2/guide/syntax.md
@@ -40,15 +40,15 @@ Mustache 标签将会被替代为对应数据对象上 `msg` 属性的值。无�
 
 <p class="tip">你的站点上动态渲染的任意 HTML 可能会非常危险，因为它很容易导致 [XSS 攻击](https://en.wikipedia.org/wiki/Cross-site_scripting)。请只对可信内容使用 HTML 插值，**绝不要**对用户提供的内容使用插值。</p>
 
-### 特性
+### 属性
 
-Mustache 语法不能作用在 HTML 特性上，遇到这种情况应该使用 [v-bind 指令](../api/#v-bind)：
+Mustache 语法不能作用在 HTML 属性上，遇到这种情况应该使用 [v-bind 指令](../api/#v-bind)：
 
 ``` html
 <div v-bind:id="dynamicId"></div>
 ```
 
-这同样适用于布尔类特性，如果求值结果是 falsy 的值 (译者注：falsy 不是 `false`，[参考这里](https://developer.mozilla.org/zh-CN/docs/Glossary/Falsy))，则该特性将会被删除：
+这同样适用于布尔类特性，如果求值结果是 falsy 的值 (译者注：falsy 不是 `false`，[参考这里](https://developer.mozilla.org/zh-CN/docs/Glossary/Falsy))，则该属性将会被删除：
 
 ``` html
 <button v-bind:disabled="isButtonDisabled">Button</button>


### PR DESCRIPTION
把“特性”改成了“属性”，一般情况下HTML标签的attribute应该翻译成“属性”，开始读这个文档时迷惑了很大一会