### PR TITLE
Update typescript.md

### DIFF
--- a/src/v2/guide/typescript.md
+++ b/src/v2/guide/typescript.md
@@ -63,9 +63,10 @@ const Component = {
   ...
 </template>
 <script lang="ts">
+import Vue, {ComponentOptions} from 'vue'
   export default {
     //类型推断已启用
-  }
+  } as ComponentOptions<Vue>
 </script>
 ```
 


### PR DESCRIPTION
在基本用法一节里,应该把 export default 的object 断言为ComponentOptions<Vue>类型的,否则不会被vetur的检测到错误,