### PR TITLE
splice 用法有误

### DIFF
--- a/src/v2/guide/list.md
+++ b/src/v2/guide/list.md
@@ -282,7 +282,7 @@ example1.items.splice(indexOfItem, 1, newValue)
 为了解决第二类问题，你可以使用 `splice`：
 
 ``` js
-example1.items.splice(newLength)
+example1.items.splice(0, newLength)
 ```
 
 ## 对象更改检测注意事项


### PR DESCRIPTION
splice 用法有误。
[1,2,3,4,5].lenght = 3  相当于[1,2,3,4,5].splice(0, 3)