### PR TITLE
删除代码注释中的 Markdown 的 ` 符号

### DIFF
--- a/src/v2/guide/components.md
+++ b/src/v2/guide/components.md
@@ -1162,7 +1162,7 @@ Vue.component('async-webpack-example', function (resolve) {
 ``` js
 Vue.component(
   'async-webpack-example',
-  // 该 `import` 函数返回一个 `Promise` 对象。
+  // 该 import 函数返回一个 Promise 对象。
   () => import('./my-async-component')
 )
 ```


### PR DESCRIPTION
此符号并不会被 Markdown 解析