### PR TITLE
过渡中关于v-enter-to和v-leave-to解释的修改

### DIFF
--- a/src/v2/guide/transitions.md
+++ b/src/v2/guide/transitions.md
@@ -99,13 +99,13 @@ new Vue({
 
 2. `v-enter-active`：定义过渡的状态。在元素整个过渡过程中作用，在元素被插入时生效，在 `transition/animation` 完成之后移除。这个类可以被用来定义过渡的过程时间，延迟和曲线函数。
 
-3. `v-enter-to`: **2.1.8版及以上** 定义进入过渡的结束状态。在元素被插入一帧后生效 (于此同时 `v-enter` 被删除)，在 `transition/animation` 完成之后移除。
+3. `v-enter-to`: **2.1.8版及以上** 定义进入过渡的结束状态。在进入过渡的最后一帧时生效，在 `transition/animation` 完成之后移除。
 
 4. `v-leave`:  定义离开过渡的开始状态。在离开过渡被触发时生效，在下一个帧移除。
 
 5. `v-leave-active`：定义过渡的状态。在元素整个过渡过程中作用，在离开过渡被触发后立即生效，在 `transition/animation` 完成之后移除。这个类可以被用来定义过渡的过程时间，延迟和曲线函数。
 
-6. `v-leave-to`: **2.1.8版及以上** 定义离开过渡的结束状态。在离开过渡被触发一帧后生效 (于此同时 `v-leave` 被删除)，在 `transition/animation` 完成之后移除。
+6. `v-leave-to`: **2.1.8版及以上** 定义离开过渡的结束状态。在离开过渡的最后一帧时生效，在 `transition/animation` 完成之后移除。
 
 ![Transition Diagram](/images/transition.png)
 


### PR DESCRIPTION
102行修改为：3. `v-enter-to`: **2.1.8版及以上** 定义进入过渡的结束状态。在进入过渡的最后一帧时生效，在 `transition/animation` 完成之后移除。
108行为改为：6. `v-leave-to`: **2.1.8版及以上** 定义离开过渡的结束状态。在离开过渡的最后一帧时生效，在 `transition/animation` 完成之后移除。

<!--

首先感谢您的参与！
为了让社区工作更有效率和质量，我们做了一些约定，希望得到您的理解和支持。

首先请阅读 README[1] 了解如何参与贡献。
如果你参与的是翻译相关的工作，有劳额外移步 wiki[2] 了解相关注意事项。

谢谢！

[1] https://github.com/vuejs/cn.vuejs.org/tree/master/README.md
[2] https://github.com/vuejs/cn.vuejs.org/wiki

-->
