### PR TITLE
fix: missing translation in style-guide

### DIFF
--- a/src/v2/style-guide/index.md
+++ b/src/v2/style-guide/index.md
@@ -180,8 +180,7 @@ new Vue({
 
 **Prop 定义应该尽量详细。**
 
-In committed code, prop definitions should always be as detailed as possible, specifying at least type(s).
-
+在你提交的代码中，prop 的定义应该尽量详细，至少需要指定其类型。
 
 {% raw %}
 <details>


### PR DESCRIPTION
1. `trailing commas` MDN的翻译为 [尾后逗号](https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Trailing_commas)， 建议改成一致？
2. 部分遗漏的翻译。