### PR TITLE
修复API导航栏部分链接锚点设置错误问题

### DIFF
--- a/themes/vue/source/js/common.js
+++ b/themes/vue/source/js/common.js
@@ -13,8 +13,9 @@
       var apiTitles = [].slice.call(apiContent.querySelectorAll('h3'))
       apiTitles.forEach(function (titleNode) {
         var methodMatch = titleNode.textContent.match(/^([^(]+)\(/)
+        var idWithoutArguments = slugize(titleNode.textContent)
         if (methodMatch) {
-          var idWithoutArguments = slugize(methodMatch[1])
+          idWithoutArguments = slugize(methodMatch[1])
           titleNode.setAttribute('id', idWithoutArguments)
           titleNode.querySelector('a').setAttribute('href', '#' + idWithoutArguments)
         }
@@ -273,8 +274,14 @@
           return ''
         }
       }).join('').replace(/\(.*\)$/, '')
+      
+      var methodMatch = h.textContent.match(/^([^(]+)\(/)
+      var idWithoutArguments = slugize(h.textContent)
+      if (methodMatch) {
+        idWithoutArguments = slugize(methodMatch[1])
+      }
       link.innerHTML =
-        '<a class="section-link" data-scroll href="#' + h.id + '">' +
+        '<a class="section-link" data-scroll href="#' + idWithoutArguments + '">' +
           htmlEscape(text) +
         '</a>'
       return link


### PR DESCRIPTION
**问题描述**

[API详情页](https://cn.vuejs.org/v2/api/)左侧导航栏，部分链接锚点设置错误，点击锚点时，右侧相应的API内容无法滚动至视口位置。如，`实例方法/数据`和`实例方法/事件`下的链接均属此类情况。

**问题根源**

左侧锚点值`(href)`和右侧对应API标签的`id`值有不同来源导致。

右侧对应API的`<h3>`标签`id`属性有两个来源：

- 若`<h3>`的`textContent`不含匹配正则式`/^([^(]+)\(/`的字符串，`id`来自模板内容自带的`id`属性

- 若`<h3>`的`textContent`含有匹配正则式`/^([^(]+)\(/`的字符串，`id`来自经处理后的`textContent`内容

而左侧锚点`href`值则来自`<h3>`标签的`id`属性，两者的值可能不相等。

**解决方案**

- 统一右侧`<h3>`标签的`id`属性来源：所有`<h3>`标签的`id`属性均由文本内容处理而来。

- 统一左侧锚点值和右侧对应`<h3>`标签的`id`属性值来源：锚点值与右侧`<h3>`标签`id`值处理方法一致。

该修改本地测试通过。