### PR TITLE
修改了components.md一处个人认为翻译的不妥之处。

### DIFF
--- a/src/v2/guide/components.md
+++ b/src/v2/guide/components.md
@@ -85,7 +85,7 @@ var Child = {
 new Vue({
   // ...
   components: {
-    // <my-component> 将只在父组件模板中可用
+    // <my-component> 将只在父实例/组件的模板中可用
     'my-component': Child
   }
 })


### PR DESCRIPTION
> 此处原文是: parent's template，

个人认为原意应是父**实例**的模板，而并不是父**组件**的模板。毕竟本章这里刚刚介绍组件，并没有讲解到父组件和子组件的配合问题。这里的parent应该指的是父实例，而不是组件。个人认为这里写上实例/组件，或者改成实例妥当一些。

<!--

首先感谢您的参与！
为了让社区工作更有效率和质量，我们做了一些约定，希望得到您的理解和支持。

首先请阅读 README[1] 了解如何参与贡献。
如果你参与的是翻译相关的工作，有劳额外移步 wiki[2] 了解相关注意事项。

谢谢！

[1] https://github.com/vuejs/cn.vuejs.org/tree/master/README.md
[2] https://github.com/vuejs/cn.vuejs.org/wiki

-->
