### PR TITLE
delete an untranslated duplicate sentence.

### DIFF
--- a/src/v2/guide/components.md
+++ b/src/v2/guide/components.md
@@ -555,7 +555,6 @@ new Vue({
 <component v-bind:is="currentTabComponent"></component>
 ```
 
-In the example above, `currentTabComponent` can contain either:
 在上述示例中，`currentTabComponent` 可以包括
 
 - 已注册组件的名字，或


### PR DESCRIPTION
The sentence 'in the component above' is already translated, so the untranslated sentence should not be left in the Chinese document.

<!--

首先感谢您的参与！
为了让社区工作更有效率和质量，我们做了一些约定，希望得到您的理解和支持。

首先请阅读 README[1] 了解如何参与贡献。
如果你参与的是翻译相关的工作，有劳额外移步 wiki[2] 了解相关注意事项。

谢谢！

[1] https://github.com/vuejs/cn.vuejs.org/tree/master/README.md
[2] https://github.com/vuejs/cn.vuejs.org/wiki

-->
