### PR TITLE
Update components.md

### DIFF
--- a/src/v2/guide/components.md
+++ b/src/v2/guide/components.md
@@ -418,8 +418,8 @@ Vue.component('custom-input', {
   template: `
     <input
       v-bind:value="value"
-      v-on:input="$emit('input', $event.target.value)
-    >
+      v-on:input="$emit('input', $event.target.value)"
+    >
   `
 })
 ```


### PR DESCRIPTION
修复：在子组件上使用v-model示例中,子组件定义时掉了后引号"

<!--

首先感谢您的参与！
为了让社区工作更有效率和质量，我们做了一些约定，希望得到您的理解和支持。

首先请阅读 README[1] 了解如何参与贡献。
如果你参与的是翻译相关的工作，有劳额外移步 wiki[2] 了解相关注意事项。

谢谢！

[1] https://github.com/vuejs/cn.vuejs.org/tree/master/README.md
[2] https://github.com/vuejs/cn.vuejs.org/wiki

-->
