### PR TITLE
组件原生事件的值传递问题

### DIFF
--- a/src/v2/guide/components-custom-events.md
+++ b/src/v2/guide/components-custom-events.md
@@ -109,7 +109,7 @@ Vue.component('base-input', {
         {
           // 这里确保组件配合 `v-model` 的工作
           input: function (event) {
-            vm.$emit('input', event.target.value)
+            vm.$emit('input', event)
           }
         }
       )


### PR DESCRIPTION
建议:
vm.$emit('input', event.target.value)更改为vm.$emit('input', event)
原因:
如果绑定的原生事件的话input是携带的是应该是事件而不是值，此处的实际情况却是携带了值，个人认为应该改为发送原来的input事件比较合适
个人愚见= =

<!--

首先感谢您的参与！
为了让社区工作更有效率和质量，我们做了一些约定，希望得到您的理解和支持。

首先请阅读 README[1] 了解如何参与贡献。
如果你参与的是翻译相关的工作，有劳额外移步 wiki[2] 了解相关注意事项。

谢谢！

[1] https://github.com/vuejs/cn.vuejs.org/tree/master/README.md
[2] https://github.com/vuejs/cn.vuejs.org/wiki

-->
