### PR TITLE
修改使用async方法的写法

### DIFF
--- a/src/v2/guide/reactivity.md
+++ b/src/v2/guide/reactivity.md
@@ -121,7 +121,7 @@ Vue.component('example', {
 
 ``` js
   methods: {
-    async updateMessage: function () {
+    async updateMessage() {
       this.message = 'updated'
       console.log(this.$el.textContent) // => '未更新'
       await this.$nextTick()


### PR DESCRIPTION
原来例子里使用async的写法有错，好像所有语言版本的这里都这样写。