### PR TITLE
Update forms.md

### DIFF
--- a/src/v2/guide/forms.md
+++ b/src/v2/guide/forms.md
@@ -64,9 +64,9 @@ new Vue({
 })
 </script>
 {% endraw %}
-
+{% raw %}
 <p class="tip">在文本区域插值 (`<textarea>{{text}}</textarea>`) 并不会生效，应用 `v-model` 来代替。</p>
-
+{% endraw %}
 ### 复选框
 
 单个复选框，绑定到布尔值：

--- a/src/v2/guide/forms.md
+++ b/src/v2/guide/forms.md
@@ -64,9 +64,11 @@ new Vue({
 })
 </script>
 {% endraw %}
+
 {% raw %}
 <p class="tip">在文本区域插值 (`<textarea>{{text}}</textarea>`) 并不会生效，应用 `v-model` 来代替。</p>
 {% endraw %}
+
 ### 复选框
 
 单个复选框，绑定到布尔值：


### PR DESCRIPTION
英文原版为：“Interpolation on textareas (<textarea>{{text}}</textarea>) won't work. Use v-model instead.”
中文译文显示：“在文本区域插值 (<textarea></textarea>) 并不会生效，应用 v-model 来代替。”  这里没有正确显示 '{{text}}'，造成理解上的困难。对比英文md发现只是缺失一对'{% raw %}', '{% endraw %}'，遂补上。

<!--

首先感谢您的参与！
为了让社区工作更有效率和质量，我们做了一些约定，希望得到您的理解和支持。

首先请阅读 README[1] 了解如何参与贡献。
如果你参与的是翻译相关的工作，有劳额外移步 wiki[2] 了解相关注意事项。

谢谢！

[1] https://github.com/vuejs/cn.vuejs.org/tree/master/README.md
[2] https://github.com/vuejs/cn.vuejs.org/wiki

-->
