### PR TITLE
Update forms.md

### DIFF
--- a/src/v2/guide/forms.md
+++ b/src/v2/guide/forms.md
@@ -66,7 +66,7 @@ new Vue({
 {% endraw %}
 
 {% raw %}
-<p class="tip">在文本区域插值 (`<textarea>{{text}}</textarea>`) 并不会生效，应用 `v-model` 来代替。</p>
+<p class="tip">在文本区域插值 (<code>&lt;textarea&gt;{{text}}&lt;/textarea&gt;</code>) 并不会生效，应用 <code>v-model</code> 来代替。</p>
 {% endraw %}
 
 ### 复选框


### PR DESCRIPTION
修复显示错误。
添加 '{% raw %} {% endraw %}' 之后 '{{ text }}' 可以显示，但'<textarea></textarea>'被解析成html。对比中英文raw md后，完成修改。