### PR TITLE
[fix]移除无效的markdown语法标识。

### DIFF
--- a/src/v2/guide/filters.md
+++ b/src/v2/guide/filters.md
@@ -10,7 +10,7 @@ Vue.js 允许你自定义过滤器，可被用于一些常见的文本格式化�
 <!-- 在双花括号中 -->
 {{ message | capitalize }}
 
-<!-- 在 `v-bind` 中 -->
+<!-- 在 v-bind 中 -->
 <div v-bind:id="rawId | formatId"></div>
 ```
 


### PR DESCRIPTION
<!--

首先感谢您的参与！
为了让社区工作更有效率和质量，我们做了一些约定，希望得到您的理解和支持。

首先请阅读 README[1] 了解如何参与贡献。
如果你参与的是翻译相关的工作，有劳额外移步 wiki[2] 了解相关注意事项。

谢谢！

[1] https://github.com/vuejs/cn.vuejs.org/tree/master/README.md
[2] https://github.com/vuejs/cn.vuejs.org/wiki

-->
移除在代码块中无效的markdown语法。
更改前：
```
<!-- 在双花括号中 -->
{{ message | capitalize }}

<!-- 在 `v-bind` 中 -->
<div v-bind:id="rawId | formatId"></div>
```
更改后：
```
<!-- 在双花括号中 -->
{{ message | capitalize }}

<!-- 在 v-bind 中 -->
<div v-bind:id="rawId | formatId"></div>
```