### PR TITLE
the old url about XSS is not found（旧的关于XSS报404，看看需不需要尝试新的地址）

### DIFF
--- a/src/v2/guide/security.md
+++ b/src/v2/guide/security.md
@@ -159,7 +159,7 @@ order: 504
 除了上述关于[潜在危险](#潜在危险)的建议，我们也推荐自行熟悉以下资料：
 
 - [HTML5 Security Cheat Sheet](https://html5sec.org/)
-- [OWASP's Cross Site Scripting (XSS) Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_%28Cross_Site_Scripting%29_Prevention_Cheat_Sheet)
+- [OWASP's Cross Site Scripting (XSS) Prevention Cheat Sheet](https://owasp.org/www-project-cheat-sheets)
 
 然后利用学到的知识，对那些包含了第三方组件或通过其它方式影响渲染到 DOM 的内容的依赖的源代码进行重新审查，以发现潜在的危险模式。
 


### PR DESCRIPTION
“https://owasp.org/www-project-cheat-sheets/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html" is not found.
Please try the new url "https://owasp.org/www-project-cheat-sheets".

<!--

首先感谢您的参与！
为了让社区工作更有效率和质量，我们做了一些约定，希望得到您的理解和支持。

首先请阅读 README[1] 了解如何参与贡献。
如果你参与的是翻译相关的工作，有劳额外移步 wiki[2] 了解相关注意事项。

谢谢！

[1] https://github.com/vuejs/cn.vuejs.org/tree/master/README.md
[2] https://github.com/vuejs/cn.vuejs.org/wiki

-->
