### PR TITLE
Update components-slots.md

### DIFF
--- a/src/v2/guide/components-slots.md
+++ b/src/v2/guide/components-slots.md
@@ -353,7 +353,7 @@ function (slotProps) {
 
 ``` html
 <base-layout>
-  <template v-slot:[dynamicSlotName]>
+  <template v-slot:[dynamic]>
     ...
   </template>
 </base-layout>


### PR DESCRIPTION
在动态插槽中，由于在动态参数表达式的约束中有：在 DOM 中使用模板时 (直接在一个 HTML 文件里撰写模板)，还需要避免使用大写字符来命名键名，因为浏览器会把 attribute 名全部强制转为小写。而案例中给定的动态指令参数是dynamicSlotName，会出现所给的案例是跑不通的情况。所以提出修改意见：可以将例子中的动态指令参数改为dynamic，避免用户在实践过程中出现跑不通的情况。

<!--

首先感谢您的参与！
为了让社区工作更有效率和质量，我们做了一些约定，希望得到您的理解和支持。

首先请阅读 README[1] 了解如何参与贡献。
如果你参与的是翻译相关的工作，有劳额外移步 wiki[2] 了解相关注意事项。

谢谢！

[1] https://github.com/vuejs/cn.vuejs.org/tree/master/README.md
[2] https://github.com/vuejs/cn.vuejs.org/wiki

-->
