### PR TITLE
Update syntax.md

### DIFF
--- a/src/v2/guide/syntax.md
+++ b/src/v2/guide/syntax.md
@@ -142,18 +142,18 @@ Mustache 语法不能作用在 HTML attribute 上，遇到这种情况应该使�
 <!--
 注意，参数表达式的写法存在一些约束，如之后的“对动态参数表达式的约束”章节所述。
 -->
-<a v-bind:[attributeName]="url"> ... </a>
+<a v-bind:[attribute_name]="url"> ... </a>
 ```
 
-这里的 `attributeName` 会被作为一个 JavaScript 表达式进行动态求值，求得的值将会作为最终的参数来使用。例如，如果你的 Vue 实例有一个 `data` property `attributeName`，其值为 `"href"`，那么这个绑定将等价于 `v-bind:href`。
+这里的 `attribute_name` 会被作为一个 JavaScript 表达式进行动态求值，求得的值将会作为最终的参数来使用。例如，如果你的 Vue 实例有一个 `data` property `attribute_name`，其值为 `"href"`，那么这个绑定将等价于 `v-bind:href`。
 
 同样地，你可以使用动态参数为一个动态的事件名绑定处理函数：
 
 ``` html
-<a v-on:[eventName]="doSomething"> ... </a>
+<a v-on:[event_name]="doSomething"> ... </a>
 ```
 
-在这个示例中，当 `eventName` 的值为 `"focus"` 时，`v-on:[eventName]` 将等价于 `v-on:focus`。
+在这个示例中，当 `event_name` 的值为 `"focus"` 时，`v-on:[event_name]` 将等价于 `v-on:focus`。
 
 #### 对动态参数的值的约束
 


### PR DESCRIPTION
动态参数的约束需要避免使用大写字符命名键名，如果直接写成attributeName浏览器会强制转换成attributename,造成代码不会工作。

<!--

首先感谢您的参与！
为了让社区工作更有效率和质量，我们做了一些约定，希望得到您的理解和支持。

首先请阅读 README[1] 了解如何参与贡献。
如果你参与的是翻译相关的工作，有劳额外移步 wiki[2] 了解相关注意事项。

谢谢！

[1] https://github.com/vuejs/cn.vuejs.org/tree/master/README.md
[2] https://github.com/vuejs/cn.vuejs.org/wiki

-->
