### PR TITLE
Update reactivity.md

### DIFF
--- a/src/v2/guide/reactivity.md
+++ b/src/v2/guide/reactivity.md
@@ -97,7 +97,7 @@ vm.$set(vm.items, indexOfItem, newValue)
 为了解决第二类问题，你可以使用 `splice`：
 
 ``` js
-vm.items.splice(newLength)
+vm.items.splice(indexOfItem, deleteCount, newValue)
 ```
 
 ## 声明响应式 property


### PR DESCRIPTION
vm.items.splice(newLength)中的newLength，如果小于等于原数组的长度是可以修改的，如果大于原数组长度是没法修改的，建议写成vm.items.splice(indexOfItem, deleteCount, newValue)，把splice的所有参数写上，这样更加的严谨，而且在实际工作中，这三个参数一般都会有

<!--

首先感谢您的参与！
为了让社区工作更有效率和质量，我们做了一些约定，希望得到您的理解和支持。

首先请阅读 README[1] 了解如何参与贡献。
如果你参与的是翻译相关的工作，有劳额外移步 wiki[2] 了解相关注意事项。

谢谢！

[1] https://github.com/vuejs/cn.vuejs.org/tree/master/README.md
[2] https://github.com/vuejs/cn.vuejs.org/wiki

-->
