### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/themes/vue/source/js/common.js
+++ b/themes/vue/source/js/common.js
@@ -119,7 +119,7 @@
   function parseRawHash (hash) {
     // Remove leading hash
     if (hash.charAt(0) === '#') {
-      hash = hash.substr(1)
+      hash = hash.slice(1)
     }
 
     // Escape characters


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.