### PR TITLE
fix(custom-directive): fix translation

### DIFF
--- a/src/v2/guide/custom-directive.md
+++ b/src/v2/guide/custom-directive.md
@@ -212,7 +212,7 @@ new Vue({
 
 ## 函数简写
 
-在很多时候，你可能想在 `bind` 和 `update` 时触发相同行为，而不关心其它的钩子。比如这样写：
+在很多时候，你可能想在 `bind` 和 `update` 时触发相同行为，而不关心其它的钩子。此时，我们可以将指令定义成一个函数：
 
 ``` js
 Vue.directive('color-swatch', function (el, binding) {


### PR DESCRIPTION
读文档的时候看到这里，发现「比如」这句话很是突兀，结合[英文文档](https://vuejs.org/guide/reusability/custom-directives.html#function-shorthand)：

> It's common for a custom directive to have the same behavior for mounted and updated, with no need for the other hooks. In such cases we can define the directive as a function:

我将其修改成了对应的形式。

<!--

首先感谢您的参与！
为了让社区工作更有效率和质量，我们做了一些约定，希望得到您的理解和支持。

首先请阅读 README[1] 了解如何参与贡献。
如果你参与的是翻译相关的工作，有劳额外移步 wiki[2] 了解相关注意事项。

谢谢！

[1] https://github.com/vuejs/cn.vuejs.org/tree/master/README.md
[2] https://github.com/vuejs/cn.vuejs.org/wiki

-->
